### PR TITLE
Use ~/.aws/config and use recommended multi profile format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ omf install https://github.com/davewongillies/plugin-awsmfa
 ```
 
 ## Configuration
-In `~/.aws/credentials`, add `username` and `account_id` settings to each profile that you want to use `awsmfa` with.
+In `~/.aws/config`, ensure you have the `mfa_serial` in each profile that you want to use `awsmfa` with as per the [AWS CLI Using Multi-Factor Authentication Docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html#cli-configure-role-mfa).
 
 ## Usage
 


### PR DESCRIPTION
Had a few problems when trying to use this plugin so I took the opportunity to fix them.

When following the AWS documentation for using multiple profiles these profiles are placed in `~/.aws/config` instead of `~/.aws/credentials` as well as using `mfa_serial` so I made adjustments to address this.

I also happened to have a newer version of ruby which the `__awsmfa_test_expiry` wasn't happy about so converted to using `date` to achieve the same thing.